### PR TITLE
[WIP] add rgb ir diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(astra_camera)
 
-find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport  nodelet sensor_msgs roscpp message_generation rospack camera_calibration_parsers)
+find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport  nodelet sensor_msgs roscpp message_generation rospack camera_calibration_parsers std_msgs)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -37,7 +37,7 @@ generate_messages()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES astra_wrapper
-  CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime rospack camera_calibration_parsers
+  CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime rospack camera_calibration_parsers std_msgs
   DEPENDS libastra
 )
 

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -128,6 +128,7 @@ private:
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
   ros::Publisher pub_fake_rgb_;
+  ros::Publisher pub_fake_depth_;
   
   /** \brief Camera info manager objects. */
   boost::shared_ptr<camera_info_manager::CameraInfoManager> color_info_manager_, ir_info_manager_;

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -127,7 +127,8 @@ private:
   image_transport::CameraPublisher pub_depth_raw_;
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
-
+  ros::Publisher pub_fake_rgb_;
+  
   /** \brief Camera info manager objects. */
   boost::shared_ptr<camera_info_manager::CameraInfoManager> color_info_manager_, ir_info_manager_;
 

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>rospack</build_depend>
   <build_depend>camera_calibration_parsers</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <run_depend>camera_info_manager</run_depend>
   <run_depend>nodelet</run_depend>
@@ -32,6 +33,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>rospack</run_depend>
   <run_depend>camera_calibration_parsers</run_depend>
+  <run_depend>std_msgs</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/astra_nodelets.xml"/>


### PR DESCRIPTION
Now, we don't have rgb and ir diagnostics since rgb and ir are publishing data when there is subscriber.

And this will make delivery abort with ar marker error like as [GTD 246] issue.

So now we need to make rgb and ir diagnostics.

However it will take lots of cpu usage, if rgb and ir publish and stream image all the time.

So that I make fake signal of rgb, and it will publish these cases.

* Depth image is publishing and ir & rgb are not publishing.
* IR is streaming and publishing
* RGB is streaming and publishing.